### PR TITLE
Log errors from mongo, don't die

### DIFF
--- a/Comedeps
+++ b/Comedeps
@@ -3,4 +3,4 @@ github.com/gorilla/pat git https://github.com/gorilla/pat.git ae2e162c4b2ae96aa6
 github.com/gorilla/mux git https://github.com/gorilla/mux.git 14cafe28513321476c73967a5a4f3454b6129c46
 github.com/gorilla/context git https://github.com/gorilla/context.git 14f550f51af52180c2eefed15e5fd18d63c0a64a
 github.com/daaku/go.httpgzip git https://github.com/daaku/go.httpgzip.git fd996995061ca6ad56e2b1b14e530edf06ce25ab
-github.com/tidepool-org/go-common git https://github.com/tidepool-org/go-common.git v0.0.2
+github.com/tidepool-org/go-common git https://github.com/tidepool-org/go-common.git v0.0.3


### PR DESCRIPTION
The code used to die from a mongo error.  Now it just logs it and returns a 500.

Also, depend on new version of go-common and update defer'd Close() of hakken to check for the error and panic if it happens

@jh-bate @kentquirk 
