### PR TITLE
Survive bad data

### DIFF
--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -133,19 +133,20 @@ func main() {
 		first := false
 		var result map[string]interface{}
 		for iter.Next(&result) {
-			if !first {
-				res.Header().Add("content-type", "application/json")
-				res.Write([]byte("["))
-				first = true
-			} else {
-				res.Write([]byte(",\n"))
-			}
 			delete(result, "groupId")
 			bytes, err := json.Marshal(result)
 			if err != nil {
-				log.Fatal(err)
+				log.Print("Failed to marshall event", result, err)
+			} else {
+				if !first {
+					res.Header().Add("content-type", "application/json")
+					res.Write([]byte("["))
+					first = true
+				} else {
+					res.Write([]byte(",\n"))
+				}
+				res.Write(bytes)
 			}
-			res.Write(bytes)
 		}
 		if err := iter.Close(); err != nil {
 			log.Print("Iterator ended with an error: ", err)


### PR DESCRIPTION
We move the marshalling of the data higher in the loop so that we can skip the element if it cannot be converted to JSON
