### PR TITLE
sort by time instead of deviceTime; remove unnecessary fields

### DIFF
--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -43,7 +43,7 @@ func main() {
 	if err := hakkenClient.Start(); err != nil {
 		log.Fatal(err)
 	}
-	defer func(){
+	defer func() {
 		if err := hakkenClient.Close(); err != nil {
 			log.Panic("Error closing hakkenClient, panicing to get stacks: ", err)
 		}
@@ -138,8 +138,6 @@ func main() {
 			delete(result, "_groupId")
 			delete(result, "_version")
 			delete(result, "_active")
-			delete(result, "createdTime")
-			delete(result, "modifiedTime")
 
 			bytes, err := json.Marshal(result)
 			if err != nil {


### PR DESCRIPTION
So _this_ is actually behind the extreme overlapping data issues @jh-bate and I were seeing with the new CareLink uploader. Tide whisperer was sorting by `deviceTime`, which is now **optional** (the sort was putting everything without a `deviceTime` at the beginning, which was extremely out of order by `time`).

@kentquirk or @jh-bate whoever can quick review... I think we could go ahead and merge and deploy; shouldn't break (or fix) anything wrt current prod uploads via in-d-gestion, but of course we should test.

I also removed `createdTime` and `modifiedTime` from the output because having so many timestamps to look at in the data bugs the crap out of me.
