### PR TITLE
added support for optional filtering parameters in the /data/userid endpoint

### DIFF
--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -66,12 +66,11 @@ func (d detailedError) setInternalMessage(internal error) detailedError {
 	return d
 }
 
-/*
-* This function takes in a number of parameters and constructs a mongo query
-* to retrieve objects from the Tidepool database. It is used by the router.Add("GET", "/{userID}"
-* endpoint, which implements the Tide-whisperer API. See that function for further documentation
-* on parameters
-**/
+
+// generateMongoQuery takes in a number of parameters and constructs a mongo query
+// to retrieve objects from the Tidepool database. It is used by the router.Add("GET", "/{userID}"
+// endpoint, which implements the Tide-whisperer API. See that function for further documentation
+// on parameters
 func generateMongoQuery(groupId string, minSchemaVersion int, maxSchemaVersion int, 
 		startDateString string, endDateString string, objType string, objSubType string) (bson.M, error) {
 
@@ -261,20 +260,19 @@ func main() {
 		return
 	}))
 	
-	/*
-	* /userid: the ID of the user you want to retrieve data for
-	* type (optional) : The Tidepool data type to search for. Only objects with a type field matching the specified type param will be returned.
-	*					can be /userid?type=smbg or a comma seperated list e.g /userid?type=smgb,cbg . If is a comma seperated 
-	*					list, then objects matching any of the sub types will be returned
-	* subtype (optional) : The Tidepool data subtype to search for. Only objects with a subtype field matching the specified subtype param will be returned.
-	*					can be /userid?subtype=physicalactivity or a comma seperated list e.g /userid?subtypetype=physicalactivity,steps . If is a comma seperated 
-	*					list, then objects matching any of the types will be returned
-	* startdate (optional) : Only objects with 'time' field equal to or greater than start date will be returned . 
-	*						  Must be in ISO date/time format e.g. 2015-10-10T15:00:00.000Z
-	* enddate (optional) : Only objects with 'time' field less than to or equal to start date will be returned . 
-	*						  Must be in ISO date/time format e.g. 2015-10-10T15:00:00.000Z 
- 	*/
-	router.Add("GET", "/{userID}", httpgzip.NewHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+	// The /data/userId endpoint retrieves device/health data for a user based on a set of parameters
+	// userid: the ID of the user you want to retrieve data for
+	// type (optional) : The Tidepool data type to search for. Only objects with a type field matching the specified type param will be returned.
+	//					can be /userid?type=smbg or a comma seperated list e.g /userid?type=smgb,cbg . If is a comma seperated 
+	//					list, then objects matching any of the sub types will be returned
+	// subtype (optional) : The Tidepool data subtype to search for. Only objects with a subtype field matching the specified subtype param will be returned.
+	//					can be /userid?subtype=physicalactivity or a comma seperated list e.g /userid?subtypetype=physicalactivity,steps . If is a comma seperated 
+	//					list, then objects matching any of the types will be returned
+	// startdate (optional) : Only objects with 'time' field equal to or greater than start date will be returned . 
+	//						  Must be in ISO date/time format e.g. 2015-10-10T15:00:00.000Z
+	// enddate (optional) : Only objects with 'time' field less than to or equal to start date will be returned . 
+	//						  Must be in ISO date/time format e.g. 2015-10-10T15:00:00.000Z 
+ 	router.Add("GET", "/{userID}", httpgzip.NewHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 
 		userToView := req.URL.Query().Get(":userID")

--- a/tide-whisperer_test.go
+++ b/tide-whisperer_test.go
@@ -1,0 +1,125 @@
+package main
+import (
+	"testing"
+	"reflect"
+	"labix.org/v2/mgo/bson"
+	"encoding/json"
+	"strings"
+)
+
+func TestGenerateMongoQuery_basic(t *testing.T) {
+	userId := "abc123"
+	minSV := 0
+	maxSV := 1
+	startDate := ""
+	endDate := ""
+	types := ""
+	subTypes := ""
+
+	mongoQuery, err := generateMongoQuery(userId, minSV, maxSV, startDate, endDate, types, subTypes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedQuery := bson.M{"_groupId": userId, 
+		"_active": true, 
+		"_schemaVersion": bson.M{"$gte": minSV, "$lte": maxSV }}
+
+	eq := reflect.DeepEqual(mongoQuery, expectedQuery)
+	if !eq {
+	    t.Fatal(getErrString(mongoQuery, expectedQuery))
+	}
+}
+
+func TestGenerateMongoQuery_allparams(t *testing.T) {
+	userId := "abc123"
+	minSV := 0
+	maxSV := 1
+	startDate := "2015-10-08T15:00:00.000Z"
+	endDate := "2015-10-11T15:00:00.000Z"
+	types := "smbg"
+	subTypes := "stype"
+
+	mongoQuery, err := generateMongoQuery(userId, minSV, maxSV, startDate, endDate, types, subTypes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedQuery := bson.M{
+		"_groupId": userId, 
+		"_active": true, 
+		"type":bson.M{"$in":strings.Split("smbg",",")},
+		"subType":bson.M{"$in":strings.Split("stype",",")},
+		"time": bson.M{"$gte": "2015-10-08T15:00:00Z", "$lte": "2015-10-11T15:00:00Z"},
+		"_schemaVersion": bson.M{"$gte": minSV, "$lte": maxSV }}
+
+	eq := reflect.DeepEqual(mongoQuery, expectedQuery)
+	if !eq {
+	    t.Fatal(getErrString(mongoQuery, expectedQuery))
+	}
+}
+
+func TestGenerateMongoQuery_badDates(t *testing.T) {
+	userId := "abc123"
+	minSV := 0
+	maxSV := 1
+	startDate := "123"
+	endDate := ""
+	types := "smbg"
+	subTypes := "stype"
+
+	mongoQuery, err := generateMongoQuery(userId, minSV, maxSV, startDate, endDate, types, subTypes)
+	if err == nil {
+		t.Fatal("should have failed to parse start date")
+	}
+
+	startDate = "2015-10-11T15:00:00.000Z"
+	endDate = "2015-10-11"
+	mongoQuery, err = generateMongoQuery(userId, minSV, maxSV, startDate, endDate, types, subTypes)
+	if err == nil {
+		t.Fatal("Should have failed to parse end date")
+	}
+
+	if mongoQuery == nil{}
+}
+
+func TestGenerateMongoQuery_multipleTypesAndSubTypes(t *testing.T) {
+	userId := "abc123"
+	minSV := 0
+	maxSV := 1
+	startDate := "2015-10-08T15:00:00.000Z"
+	endDate := "2015-10-11T15:00:00.000Z"
+	types := "smbg,physicalActivity"
+	subTypes := "stype1,stype2"
+
+	mongoQuery, err := generateMongoQuery(userId, minSV, maxSV, startDate, endDate, types, subTypes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedQuery := bson.M{
+		"_groupId": userId, 
+		"_active": true, 
+		"type":bson.M{"$in":strings.Split(types,",")},
+		"subType":bson.M{"$in":strings.Split(subTypes,",")},
+		"time": bson.M{"$gte": "2015-10-08T15:00:00Z", "$lte": "2015-10-11T15:00:00Z"},
+		"_schemaVersion": bson.M{"$gte": minSV, "$lte": maxSV }}
+
+	eq := reflect.DeepEqual(mongoQuery, expectedQuery)
+	if !eq {
+	    t.Fatal(getErrString(mongoQuery, expectedQuery))
+	}
+}
+
+func getErrString(mongoQuery, expectedQuery bson.M) string {
+	exp, err1 := json.MarshalIndent(expectedQuery, "", "  ")
+	mq, err2 := json.MarshalIndent(mongoQuery, "", "  ")
+	errStr := "expected:\n"+string(exp)+"\ndid not match returned query\n"+string(mq)
+	if err1 == nil && err2 == nil {}
+	return errStr
+
+}
+
+
+
+


### PR DESCRIPTION
Added optional parameters to the endpoint:
- startdate
- enddate
- type
- subtype

These are all optional and should not break the break the functionality of the current endpoint. 
The optional parameters allow developers to more selectively pull subsets of data from Tidepool
