### PR TITLE
Do not return Carelink data if any Medtronic Direct upload; query parameter to force inclusion

### DIFF
--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -134,8 +134,8 @@ func main() {
 		jsonErr, _ := json.Marshal(err)
 
 		res.Header().Add("content-type", "application/json")
-		res.Write(jsonErr)
 		res.WriteHeader(err.Status)
+		res.Write(jsonErr)
 	}
 
 	processResults := func(response http.ResponseWriter, iterator StorageIterator, startTime time.Time) {

--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -51,11 +51,11 @@ type (
 var (
 	error_status_check = detailedError{Status: http.StatusInternalServerError, Code: "data_status_check", Message: "checking of the status endpoint showed an error"}
 
-	error_no_view_permisson    = detailedError{Status: http.StatusForbidden, Code: "data_cant_view", Message: "user is not authorized to view data"}
-	error_no_permissons        = detailedError{Status: http.StatusInternalServerError, Code: "data_perms_error", Message: "error finding permissons for user"}
-	error_running_query        = detailedError{Status: http.StatusInternalServerError, Code: "data_store_error", Message: "internal server error"}
-	error_loading_events       = detailedError{Status: http.StatusInternalServerError, Code: "data_marshal_error", Message: "internal server error"}
-	error_incorrect_dateparams = detailedError{Status: http.StatusInternalServerError, Code: "date_params", Message: "dates be in ISO date/time format e.g. 2015-10-10T15:00:00.000Z"}
+	error_no_view_permisson  = detailedError{Status: http.StatusForbidden, Code: "data_cant_view", Message: "user is not authorized to view data"}
+	error_no_permissons      = detailedError{Status: http.StatusInternalServerError, Code: "data_perms_error", Message: "error finding permissons for user"}
+	error_running_query      = detailedError{Status: http.StatusInternalServerError, Code: "data_store_error", Message: "internal server error"}
+	error_loading_events     = detailedError{Status: http.StatusInternalServerError, Code: "data_marshal_error", Message: "internal server error"}
+	error_invalid_parameters = detailedError{Status: http.StatusInternalServerError, Code: "invalid_parameters", Message: "one or more parameters are invalid"}
 
 	store Storage
 )
@@ -207,7 +207,7 @@ func main() {
 
 		if err != nil {
 			log.Println(DATA_API_PREFIX, fmt.Sprintf("Error parsing date: %s", err))
-			jsonError(res, error_incorrect_dateparams, start)
+			jsonError(res, error_invalid_parameters, start)
 			return
 		}
 

--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -219,6 +219,16 @@ func main() {
 			return
 		}
 
+		if _, ok := req.URL.Query()["carelink"]; !ok {
+			if hasMedtronicDirectData, err := store.HasMedtronicDirectData(queryParams.userId); err != nil {
+				log.Println(DATA_API_PREFIX, fmt.Sprintf("Error while querying for Medtronic Direct data: %s", err))
+				jsonError(res, error_running_query, start)
+				return
+			} else if !hasMedtronicDirectData {
+				queryParams.carelink = true
+			}
+		}
+
 		pair := seagullClient.GetPrivatePair(queryParams.userId, "uploads", shorelineClient.TokenProvide())
 		if pair == nil {
 			jsonError(res, error_no_permissons, start)


### PR DESCRIPTION
@jh-bate If the query parameter is not specified (the default), then Carelink data will only be returned IFF there is no Medtronic Direct data. If the query is specified (as a boolean), then Carelink data is included (or not) per that boolean (the presence of Medtronic Direct data is irrelevant).