### PR TITLE
Filter cbg data if Dexcom API data present

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -91,6 +91,10 @@ func allParamsQuery() bson.M {
 		Types:         []string{"smbg", "cbg"},
 		SubTypes:      []string{"stuff"},
 		Carelink:      true,
+		DexcomDataSource: bson.M{
+			"dataSetIds":       []string{"123", "456"},
+			"earliestDataTime": "2015-10-07T15:00:00Z",
+		},
 	}
 
 	return generateMongoQuery(qParams)
@@ -140,6 +144,11 @@ func TestStore_generateMongoQuery_allparams(t *testing.T) {
 		"time": bson.M{
 			"$gte": "2015-10-07T15:00:00.000Z",
 			"$lte": "2015-10-11T15:00:00.000Z"},
+		"$or": []bson.M{
+			{"type": bson.M{"$ne": "cbg"}},
+			{"uploadId": bson.M{"$in": []string{"123", "456"}}},
+			{"time": bson.M{"$lt": "2015-10-07T15:00:00Z"}},
+		},
 	}
 
 	eq := reflect.DeepEqual(query, expectedQuery)

--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -212,12 +212,21 @@ func main() {
 		}
 
 		if _, ok := req.URL.Query()["carelink"]; !ok {
-			if hasMedtronicDirectData, err := storage.HasMedtronicDirectData(queryParams.UserId); err != nil {
-				log.Println(DATA_API_PREFIX, fmt.Sprintf("Error while querying for Medtronic Direct data: %s", err))
+			if hasMedtronicDirectData, medtronicErr := storage.HasMedtronicDirectData(queryParams.UserId); medtronicErr != nil {
+				log.Println(DATA_API_PREFIX, fmt.Sprintf("Error while querying for Medtronic Direct data: %s", medtronicErr))
 				jsonError(res, error_running_query, start)
 				return
 			} else if !hasMedtronicDirectData {
 				queryParams.Carelink = true
+			}
+		}
+		if !queryParams.Dexcom {
+			if dexcomDataSource, dexcomErr := storage.GetDexcomDataSource(queryParams.UserId); dexcomErr != nil {
+				log.Println(DATA_API_PREFIX, fmt.Sprintf("Error while querying for Dexcom data source: %s", dexcomErr))
+				jsonError(res, error_running_query, start)
+				return
+			} else {
+				queryParams.DexcomDataSource = dexcomDataSource
 			}
 		}
 


### PR DESCRIPTION
@jh-bate @pazaan If the "dexcom=true" query parameter is not set, then filter out all cbg data not from the Dexcom API during the Dexcom API time period forward.