### PR TITLE
Support restricted tokens for authentication

### DIFF
--- a/auth/client.go
+++ b/auth/client.go
@@ -1,0 +1,75 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+type Config struct {
+	Address       string `json:"address"`
+	ServiceSecret string `json:"serviceSecret"`
+	UserAgent     string `json:"userAgent"`
+}
+
+type Client struct {
+	config     *Config
+	httpClient *http.Client
+}
+
+func NewClient(config *Config, httpClient *http.Client) (*Client, error) {
+	if config == nil {
+		return nil, errors.New("config is missing")
+	}
+	if httpClient == nil {
+		return nil, errors.New("http client is missing")
+	}
+
+	return &Client{
+		config:     config,
+		httpClient: httpClient,
+	}, nil
+}
+
+func (c *Client) GetRestrictedToken(ctx context.Context, id string) (*RestrictedToken, error) {
+	if ctx == nil {
+		return nil, errors.New("context is missing")
+	}
+	if id == "" {
+		return nil, errors.New("id is missing")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/restricted_tokens/%s", c.config.Address, id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req = req.WithContext(ctx)
+
+	req.Header.Add("X-Tidepool-Service-Secret", c.config.ServiceSecret)
+	req.Header.Add("User-Agent", c.config.UserAgent)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		io.Copy(ioutil.Discard, res.Body)
+		res.Body.Close()
+	}()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New("unexpected status code")
+	}
+
+	restrictedToken := &RestrictedToken{}
+	if err = json.NewDecoder(res.Body).Decode(restrictedToken); err != nil {
+		return nil, err
+	}
+
+	return restrictedToken, nil
+}

--- a/auth/client_test.go
+++ b/auth/client_test.go
@@ -1,0 +1,129 @@
+package auth_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tidepool-org/tide-whisperer/auth"
+)
+
+func testClientSetup(address string) (*auth.Config, *http.Client) {
+	config := &auth.Config{
+		Address:       address,
+		ServiceSecret: "ThisIsASecret!",
+		UserAgent:     "Test-Agent",
+	}
+	httpClient := &http.Client{}
+	return config, httpClient
+}
+
+func testServerClientSetup(handlerFunc http.HandlerFunc) (*httptest.Server, *auth.Client, context.Context) {
+	server := httptest.NewServer(handlerFunc)
+	client, _ := auth.NewClient(testClientSetup(server.URL))
+	ctx := context.Background()
+	return server, client, ctx
+}
+
+func Test_NewClient_ConfigMissing(t *testing.T) {
+	config, httpClient := testClientSetup("http://localhost/alfa/bravo")
+	config = nil
+	client, err := auth.NewClient(config, httpClient)
+	if err == nil || err.Error() != "config is missing" || client != nil {
+		t.Error(err, "NewClient fails to return expected error and no client config missing")
+	}
+}
+
+func Test_NewClient_HttpClientMissing(t *testing.T) {
+	config, httpClient := testClientSetup("http://localhost/alfa/bravo")
+	httpClient = nil
+	client, err := auth.NewClient(config, httpClient)
+	if err == nil || err.Error() != "http client is missing" || client != nil {
+		t.Error(err, "NewClient fails to return expected error and no client http client missing")
+	}
+}
+
+func Test_NewClient_Valid(t *testing.T) {
+	config, httpClient := testClientSetup("http://localhost/alfa/bravo")
+	client, err := auth.NewClient(config, httpClient)
+	if err != nil || client == nil {
+		t.Error(err, "NewClient fails to return no error and client")
+	}
+}
+
+func Test_Client_GetRestrictedToken_ContextMissing(t *testing.T) {
+	id := "1234567890"
+	server, client, ctx := testServerClientSetup(func(res http.ResponseWriter, req *http.Request) {})
+	defer server.Close()
+	ctx = nil
+	restrictedToken, err := client.GetRestrictedToken(ctx, id)
+	if err == nil || err.Error() != "context is missing" || restrictedToken != nil {
+		t.Error(err, "Client.GetRestrictedToken fails to return expected error and no restricted token context missing")
+	}
+}
+
+func Test_Client_GetRestrictedToken_IDMissing(t *testing.T) {
+	id := ""
+	server, client, ctx := testServerClientSetup(func(res http.ResponseWriter, req *http.Request) {})
+	defer server.Close()
+	restrictedToken, err := client.GetRestrictedToken(ctx, id)
+	if err == nil || err.Error() != "id is missing" || restrictedToken != nil {
+		t.Error(err, "Client.GetRestrictedToken fails to return expected error and no restricted token id missing")
+	}
+}
+
+func Test_Client_GetRestrictedToken_UnexpectedStatusCode(t *testing.T) {
+	id := "1234567890"
+	server, client, ctx := testServerClientSetup(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusBadRequest)
+	})
+	defer server.Close()
+	restrictedToken, err := client.GetRestrictedToken(ctx, id)
+	if err == nil || err.Error() != "unexpected status code" || restrictedToken != nil {
+		t.Error(err, "Client.GetRestrictedToken fails to return expected error and no restricted token unexpected status code")
+	}
+}
+
+func Test_Client_GetRestrictedToken_MalformedJSON(t *testing.T) {
+	id := "1234567890"
+	server, client, ctx := testServerClientSetup(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusOK)
+		res.Write([]byte("{"))
+	})
+	defer server.Close()
+	restrictedToken, err := client.GetRestrictedToken(ctx, id)
+	if err == nil || err.Error() != "unexpected EOF" || restrictedToken != nil {
+		t.Error(err, "Client.GetRestrictedToken fails to return expected error and no restricted token malformed JSON")
+	}
+}
+
+func Test_Client_GetRestrictedToken_Valid(t *testing.T) {
+	id := "1234567890"
+	userID := "9876543210"
+	server, client, ctx := testServerClientSetup(func(res http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Error("Client.GetRestrictedToken fails to use expected method")
+		}
+		if req.URL.Path != fmt.Sprintf("/v1/restricted_tokens/%s", id) {
+			t.Error("Client.GetRestrictedToken fails to use expected path")
+		}
+		if req.Header.Get("X-Tidepool-Service-Secret") != "ThisIsASecret!" {
+			t.Error("Client.GetRestrictedToken fails to add expected header with service secret")
+		}
+		if req.Header.Get("User-Agent") != "Test-Agent" {
+			t.Error("Client.GetRestrictedToken fails to add expected header with user agent")
+		}
+		res.WriteHeader(http.StatusOK)
+		res.Write([]byte(fmt.Sprintf(`{"id": "%s", "userId": "%s"}`, id, userID)))
+	})
+	defer server.Close()
+	restrictedToken, err := client.GetRestrictedToken(ctx, id)
+	if err != nil || restrictedToken == nil {
+		t.Error(err, "Client.GetRestrictedToken fails to return no error and restricted token")
+	}
+	if restrictedToken.UserID != userID {
+		t.Error("Client.GetRestrictedToken fails to return expected restricted token")
+	}
+}

--- a/auth/restricted_token.go
+++ b/auth/restricted_token.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+type RestrictedToken struct {
+	ID             string     `json:"id"`
+	UserID         string     `json:"userId"`
+	Paths          *[]string  `json:"paths,omitempty"`
+	ExpirationTime time.Time  `json:"expirationTime"`
+	CreatedTime    time.Time  `json:"createdTime"`
+	ModifiedTime   *time.Time `json:"modifiedTime,omitempty"`
+}
+
+func (r *RestrictedToken) Authenticates(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	if time.Now().After(r.ExpirationTime) {
+		return false
+	}
+	if r.Paths != nil {
+		escapedPath := req.URL.EscapedPath()
+		for _, path := range *r.Paths {
+			if path == escapedPath || strings.HasPrefix(escapedPath, strings.TrimSuffix(path, "/")+"/") {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}

--- a/auth/restricted_token_test.go
+++ b/auth/restricted_token_test.go
@@ -1,0 +1,93 @@
+package auth_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tidepool-org/tide-whisperer/auth"
+)
+
+func testRestrictedTokenSetup(url string) (*http.Request, *auth.RestrictedToken) {
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	restrictedToken := &auth.RestrictedToken{
+		Paths:          &[]string{"/alfa/bravo", "/charlie/delta"},
+		ExpirationTime: time.Now().Add(time.Hour),
+	}
+	return req, restrictedToken
+}
+
+func Test_RestrictedToken_Authenticates_MissingRequest(t *testing.T) {
+	req, restrictedToken := testRestrictedTokenSetup("http://localhost/charlie/delta")
+	req = nil
+	if restrictedToken.Authenticates(req) {
+		t.Error("RestrictedToken.Authenticates fails to not authenticate missing request")
+	}
+}
+
+func Test_RestrictedToken_Authenticates_MissingRequestURL(t *testing.T) {
+	req, restrictedToken := testRestrictedTokenSetup("http://localhost/charlie/delta")
+	req.URL = nil
+	if restrictedToken.Authenticates(req) {
+		t.Error("RestrictedToken.Authenticates fails to not authenticate missing request url")
+	}
+}
+
+func Test_RestrictedToken_Authenticates_ExpiredRestrictedToken(t *testing.T) {
+	req, restrictedToken := testRestrictedTokenSetup("http://localhost/charlie/delta")
+	restrictedToken.ExpirationTime = time.Now().Add(-time.Hour)
+	if restrictedToken.Authenticates(req) {
+		t.Error("RestrictedToken.Authenticates fails to not authenticate expired restricted token")
+	}
+}
+
+func Test_RestrictedToken_Authenticates_PathsEmpty(t *testing.T) {
+	req, restrictedToken := testRestrictedTokenSetup("http://localhost/charlie/delta")
+	restrictedToken.Paths = &[]string{}
+	if restrictedToken.Authenticates(req) {
+		t.Error("RestrictedToken.Authenticates fails to not authenticate paths empty")
+	}
+}
+
+func Test_RestrictedToken_Authenticates_PathNotFound(t *testing.T) {
+	req, restrictedToken := testRestrictedTokenSetup("http://localhost/yankee/zulu")
+	if restrictedToken.Authenticates(req) {
+		t.Error("RestrictedToken.Authenticates fails to not authenticate path not found")
+	}
+}
+
+func Test_RestrictedToken_Authenticates_PartialPrefix(t *testing.T) {
+	req, restrictedToken := testRestrictedTokenSetup("http://localhost/charlie/deltaecho/foxtrot")
+	if restrictedToken.Authenticates(req) {
+		t.Error("RestrictedToken.Authenticates fails to not authenticate partial prefix")
+	}
+}
+
+func Test_RestrictedToken_Authenticates_Valid(t *testing.T) {
+	req, restrictedToken := testRestrictedTokenSetup("http://localhost/charlie/delta")
+	if !restrictedToken.Authenticates(req) {
+		t.Error("RestrictedToken.Authenticates fails to authenticate valid")
+	}
+}
+
+func Test_RestrictedToken_Authenticates_ValidTrailingSlash(t *testing.T) {
+	req, restrictedToken := testRestrictedTokenSetup("http://localhost/charlie/delta/")
+	if !restrictedToken.Authenticates(req) {
+		t.Error("RestrictedToken.Authenticates fails to authenticate valid trailing slash")
+	}
+}
+
+func Test_RestrictedToken_Authenticates_ValidPrefix(t *testing.T) {
+	req, restrictedToken := testRestrictedTokenSetup("http://localhost/charlie/delta/echo/foxtrot")
+	if !restrictedToken.Authenticates(req) {
+		t.Error("RestrictedToken.Authenticates fails to authenticate valid prefix")
+	}
+}
+
+func Test_RestrictedToken_Authenticates_ValidWithoutPaths(t *testing.T) {
+	req, restrictedToken := testRestrictedTokenSetup("http://localhost/yankee/zulu")
+	restrictedToken.Paths = nil
+	if !restrictedToken.Authenticates(req) {
+		t.Error("RestrictedToken.Authenticates fails to authenticate valid without paths")
+	}
+}


### PR DESCRIPTION
@jh-bate Before you ask, there is no way to test the new code in the main handler without a massive amount of support code. You'll note that there are no tests for the entire handler as it is, so I'm not about to spend a ton of time writing test support code for the handler when the whole service is on the cusp of being deprecated. All of the other new code has full tests, though.