### PR TITLE
Allow 'sort', 'limit', and 'uploadId' query params for patient data endpoint

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -93,7 +93,7 @@ func GetParams(q url.Values, schema *SchemaVersion) (*Params, error) {
 	}
 
 	sortStr := q.Get("sort")
-	if sortStr == "" {
+	if len(sortStr) < 1 || sortStr == "" {
 		sortStr = "$natural"
 	}
 	sort := strings.Split(sortStr, ",")
@@ -198,10 +198,6 @@ func generateMongoQuery(p *Params) bson.M {
 		groupDataQuery["subType"] = bson.M{"$in": p.SubTypes}
 	}
 
-	if p.UploadId != "" {
-		groupDataQuery["uploadId"] = p.UploadId
-	}
-
 	if p.Date.Start != "" && p.Date.End != "" {
 		groupDataQuery["time"] = bson.M{"$gte": p.Date.Start, "$lte": p.Date.End}
 	} else if p.Date.Start != "" {
@@ -215,6 +211,13 @@ func generateMongoQuery(p *Params) bson.M {
 	}
 
 	andQuery := []bson.M{}
+	if p.UploadId != "" {
+		uploadIDQuery := []bson.M{
+			{"uploadId": p.UploadId},
+		}
+		andQuery = append(andQuery, bson.M{"$or": uploadIDQuery})
+	}
+
 	if !p.Dexcom && p.DexcomDataSource != nil {
 		dexcomQuery := []bson.M{
 			{"type": bson.M{"$ne": "cbg"}},

--- a/store/store.go
+++ b/store/store.go
@@ -210,6 +210,8 @@ func generateMongoQuery(p *Params) bson.M {
 		groupDataQuery["source"] = bson.M{"$ne": "carelink"}
 	}
 
+	// If we have an explicit upload ID to filter by, we don't need or want to apply any further
+	// data source-based filtering
 	if p.UploadId != "" {
 		groupDataQuery["uploadId"] = p.UploadId
 	} else {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -281,6 +281,7 @@ func TestStore_GetParams_Empty(t *testing.T) {
 		SchemaVersion: schema,
 		Types:         []string{""},
 		SubTypes:      []string{""},
+		Sort:          []string{"$natural"},
 	}
 
 	params, err := GetParams(query, schema)
@@ -306,6 +307,7 @@ func TestStore_GetParams_Medtronic(t *testing.T) {
 		Types:         []string{""},
 		SubTypes:      []string{""},
 		Medtronic:     true,
+		Sort:          []string{"$natural"},
 	}
 
 	params, err := GetParams(query, schema)

--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -168,6 +168,7 @@ func main() {
 
 	// The /data/userId endpoint retrieves device/health data for a user based on a set of parameters
 	// userid: the ID of the user you want to retrieve data for
+	// uploadId (optional) : Search for Tidepool data by uploadId. Only objects with a uploadId field matching the specified uploadId param will be returned.
 	// type (optional) : The Tidepool data type to search for. Only objects with a type field matching the specified type param will be returned.
 	//					can be /userid?type=smbg or a comma seperated list e.g /userid?type=smgb,cbg . If is a comma seperated
 	//					list, then objects matching any of the sub types will be returned
@@ -175,16 +176,20 @@ func main() {
 	//					can be /userid?subtype=physicalactivity or a comma seperated list e.g /userid?subtypetype=physicalactivity,steps . If is a comma seperated
 	//					list, then objects matching any of the types will be returned
 	// startDate (optional) : Only objects with 'time' field equal to or greater than start date will be returned .
-	//						  Must be in ISO date/time format e.g. 2015-10-10T15:00:00.000Z
+	//					Must be in ISO date/time format e.g. 2015-10-10T15:00:00.000Z
 	// endDate (optional) : Only objects with 'time' field less than to or equal to start date will be returned .
-	//						  Must be in ISO date/time format e.g. 2015-10-10T15:00:00.000Z
+	//					Must be in ISO date/time format e.g. 2015-10-10T15:00:00.000Z
+	// limit (optional) : Restricts the maximum number of documents retrieved
+	// sort (optional) : The Tidepool data fields to sort by.
+	//					can be /userid?sort=-time for a descending sort by the `time` field, or a comma seperated list e.g /userid?sort=uploadId,time ,
+	//					which would sort the results first by uploadId, and then by time, both in ascending order
 	router.Add("GET", "/{userID}", httpgzip.NewHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 
 		queryParams, err := store.GetParams(req.URL.Query(), &config.SchemaVersion)
 
 		if err != nil {
-			log.Println(DATA_API_PREFIX, fmt.Sprintf("Error parsing date: %s", err))
+			log.Println(DATA_API_PREFIX, fmt.Sprintf("Error parsing query params: %s", err))
 			jsonError(res, error_invalid_parameters, start)
 			return
 		}


### PR DESCRIPTION
Needed so that we can fetch just the latest pump settings and upload datums to fix this bug: https://trello.com/c/xNVdNQ1W

Goes hand-in-hand with these PRs:
tidepool-org/blip#551
tidepool-org/platform-client#96