### PR TITLE
Prohibit natural sort query param

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -94,7 +94,7 @@ func GetParams(q url.Values, schema *SchemaVersion) (*Params, error) {
 
 	sortStr := q.Get("sort")
 	if len(sortStr) < 1 || sortStr == "" {
-		sortStr = "$natural"
+		sortStr = "-time"
 	}
 	sort := strings.Split(sortStr, ",")
 

--- a/store/store.go
+++ b/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/url"
 	"strconv"
@@ -97,6 +98,11 @@ func GetParams(q url.Values, schema *SchemaVersion) (*Params, error) {
 		sortStr = "-time"
 	}
 	sort := strings.Split(sortStr, ",")
+	for _, s := range sort {
+		if s == "$natural" {
+			return nil, fmt.Errorf("sort param %s is prohibited", s)
+		}
+	}
 
 	var limit int
 	if values, ok := q["limit"]; ok {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -363,7 +363,7 @@ func TestStore_GetParams_Empty(t *testing.T) {
 		SchemaVersion: schema,
 		Types:         []string{""},
 		SubTypes:      []string{""},
-		Sort:          []string{"$natural"},
+		Sort:          []string{"-time"},
 	}
 
 	params, err := GetParams(query, schema)
@@ -389,7 +389,7 @@ func TestStore_GetParams_Medtronic(t *testing.T) {
 		Types:         []string{""},
 		SubTypes:      []string{""},
 		Medtronic:     true,
-		Sort:          []string{"$natural"},
+		Sort:          []string{"-time"},
 	}
 
 	params, err := GetParams(query, schema)
@@ -414,7 +414,7 @@ func TestStore_GetParams_UploadId(t *testing.T) {
 		SchemaVersion: schema,
 		Types:         []string{""},
 		SubTypes:      []string{""},
-		Sort:          []string{"$natural"},
+		Sort:          []string{"-time"},
 		UploadId:      "xyz123",
 	}
 
@@ -439,7 +439,7 @@ func TestStore_GetParams_Default_Sort(t *testing.T) {
 		SchemaVersion: schema,
 		Types:         []string{""},
 		SubTypes:      []string{""},
-		Sort:          []string{"$natural"},
+		Sort:          []string{"-time"},
 	}
 
 	params, err := GetParams(query, schema)
@@ -464,7 +464,7 @@ func TestStore_GetParams_Empty_Sort(t *testing.T) {
 		SchemaVersion: schema,
 		Types:         []string{""},
 		SubTypes:      []string{""},
-		Sort:          []string{"$natural"},
+		Sort:          []string{"-time"},
 	}
 
 	params, err := GetParams(query, schema)
@@ -514,7 +514,7 @@ func TestStore_GetParams_Limit(t *testing.T) {
 		SchemaVersion: schema,
 		Types:         []string{""},
 		SubTypes:      []string{""},
-		Sort:          []string{"$natural"},
+		Sort:          []string{"-time"},
 		Limit:         10,
 	}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -528,6 +528,25 @@ func TestStore_GetParams_Limit(t *testing.T) {
 	}
 }
 
+func TestStore_GetParams_Sort_Natural_Prohibited_Error(t *testing.T) {
+	query := url.Values{
+		":userID": []string{"1122334455"},
+		"sort":    []string{"-time,$natural"},
+	}
+	schema := &SchemaVersion{Minimum: 1, Maximum: 3}
+
+	expectedError := errors.New("sort param $natural is prohibited")
+
+	_, err := GetParams(query, schema)
+
+	if err == nil {
+		t.Error("should have received error, but got nil")
+	}
+	if err.Error() != expectedError.Error() {
+		t.Error(fmt.Sprintf("error %s does not equal expected error %s", err, expectedError))
+	}
+}
+
 func TestStore_GetParams_Limit_Value_Missing_Error(t *testing.T) {
 	query := url.Values{
 		":userID": []string{"1122334455"},


### PR DESCRIPTION
Fix for performance issues encountered when testing https://trello.com/c/5GE2xbcZ

For reasons outlined [here](https://docs.mongodb.com/manual/reference/method/cursor.sort/#index-use), defaulting to `$natural` sort was causing the index to be missed.

This PR sets the default sort to be set to `-time`, which is backwards compatible with the index we typically hit for data fetching in Tidepool Web.  It also returns an error if `$natural` is specified as the sort param.