### PR TITLE
[BACK-1269] Improve `latest` performance

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -63,9 +63,19 @@ type (
 		End   string
 	}
 
-	ClosingSessionIterator struct {
+	returnIterator interface {
+		Close() error
+		Next(result interface{}) bool
+	}
+
+	latestIterator struct {
+		Iterators []*mgo.Iter
+		pos       int
+	}
+
+	closingSessionIterator struct {
 		*mgo.Session
-		*mgo.Iter
+		Iter returnIterator
 	}
 )
 
@@ -392,66 +402,32 @@ func (d MongoStoreClient) GetDeviceData(p *Params) StorageIterator {
 	// closes session when the iterator is closed. See ClosingSessionIterator below.
 	session := d.session.Copy()
 
-	var iter *mgo.Iter
+	var iter returnIterator
 
 	if p.Latest {
-		// Create an $aggregate query to return the latest of each `type` requested
-		// that matches the query parameters
-		pipeline := []bson.M{
-			{
-				"$match": generateMongoQuery(p),
-			},
-			{
-				"$sort": bson.M{
-					"type": 1,
-					"time": -1,
-				},
-			},
-			{
-				"$group": bson.M{
-					"_id": bson.M{
-						"userId": "$_userId",
-						"type":   "$type",
-					},
-					"groupId": bson.M{
-						"$first": "$time",
-					},
-				},
-			},
-			{
-				"$lookup": bson.M{
-					"from": "deviceData",
-					"let":  bson.M{"searchUserId": "$_id.userId", "searchType": "$_id.type", "searchTime": "$groupId"},
-					"pipeline": []bson.M{
-						{
-							"$match": bson.M{
-								"$expr": bson.M{
-									"$and": []bson.M{
-										{"$eq": []string{"$_userId", "$$searchUserId"}},
-										{"$eq": []interface{}{"$_active", true}},
-										{"$eq": []string{"$type", "$$searchType"}},
-										{"$gt": []interface{}{"$_schemaVersion", 0}},
-										{"$eq": []string{"$time", "$$searchTime"}},
-									},
-								},
-							},
-						},
-						{"$limit": 1},
-					},
-					"as": "latest_doc",
-				},
-			},
-			{
-				"$unwind": "$latest_doc",
-			},
-			{
-				"$replaceRoot": bson.M{
-					"newRoot": "$latest_doc",
-				},
-			},
+		latest := &latestIterator{pos: 0, Iterators: []*mgo.Iter{}}
+
+		var typeRanges []string
+		if len(p.Types) > 0 && p.Types[0] != "" {
+			typeRanges = p.Types
+		} else {
+			typeRanges = []string{"physicalActivity", "basal", "cbg", "smbg", "bloodKetone", "bolus", "wizard", "deviceEvent", "food", "insulin", "cgmSettings", "pumpSettings", "reportedState", "upload"}
 		}
-		pipe := mgoDataCollection(session).Pipe(pipeline).AllowDiskUse()
-		iter = pipe.Iter()
+		for _, theType := range typeRanges {
+			query := generateMongoQuery(p)
+			query["type"] = theType
+			result := mgoDataCollection(session).
+				Find(query).
+				Select(removeFieldsForReturn).
+				Sort("-time").
+				Limit(1).
+				Iter()
+			if !result.Done() {
+				latest.Append(result)
+			}
+		}
+
+		iter = latest
 	} else {
 		iter = mgoDataCollection(session).
 			Find(generateMongoQuery(p)).
@@ -459,17 +435,38 @@ func (d MongoStoreClient) GetDeviceData(p *Params) StorageIterator {
 			Iter()
 	}
 
-	return &ClosingSessionIterator{session, iter}
+	return &closingSessionIterator{session, iter}
 }
 
-func (i *ClosingSessionIterator) Next(result interface{}) bool {
+func (l *latestIterator) Append(itr *mgo.Iter) {
+	l.Iterators = append(l.Iterators, itr)
+}
+
+func (l *latestIterator) Next(result interface{}) bool {
+	if len(l.Iterators) == l.pos {
+		return false
+	}
+
+	l.Iterators[l.pos].Next(result)
+	l.pos++
+	return true
+}
+
+func (l *latestIterator) Close() (err error) {
+	for _, i := range l.Iterators {
+		err = i.Close()
+	}
+	return err
+}
+
+func (i *closingSessionIterator) Next(result interface{}) bool {
 	if i.Iter != nil {
 		return i.Iter.Next(result)
 	}
 	return false
 }
 
-func (i *ClosingSessionIterator) Close() (err error) {
+func (i *closingSessionIterator) Close() (err error) {
 	if i.Iter != nil {
 		err = i.Iter.Close()
 		i.Iter = nil

--- a/store/store.go
+++ b/store/store.go
@@ -447,7 +447,9 @@ func (l *latestIterator) Next(result interface{}) bool {
 		return false
 	}
 
-	l.Iterators[l.pos].Next(result)
+	if l.Iterators[l.pos] != nil {
+		l.Iterators[l.pos].Next(result)
+	}
 	l.pos++
 	return true
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -213,10 +213,10 @@ func testDataForLatestTests() map[string]bson.M {
 	return testData
 }
 
-func outputData(inputData bson.M) bson.M {
+func dropInternalKeys(inputData bson.M) bson.M {
 	outputData := bson.M{}
 	for k, v := range inputData {
-		if string(k[0]) != "_" {
+		if !strings.HasPrefix(k, "_") {
 			outputData[k] = v
 		}
 	}
@@ -1066,14 +1066,14 @@ func TestStore_LatestNoFilter(t *testing.T) {
 		switch dataType := result["type"]; dataType {
 		case "cbg":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			compareResult := outputData(testData["cbg1"])
+			compareResult := dropInternalKeys(testData["cbg1"])
 			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'cbg' result when requesting latest data")
 			}
 			processedResultCount++
 		case "upload":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			compareResult := outputData(testData["upload1"])
+			compareResult := dropInternalKeys(testData["upload1"])
 			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'upload' result when requesting latest data")
 			}
@@ -1108,7 +1108,7 @@ func TestStore_LatestTypeFilter(t *testing.T) {
 		switch dataType := result["type"]; dataType {
 		case "cbg":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			compareResult := outputData(testData["cbg1"])
+			compareResult := dropInternalKeys(testData["cbg1"])
 			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'cbg' result when requesting latest data")
 			}
@@ -1143,14 +1143,14 @@ func TestStore_LatestUploadIdFilter(t *testing.T) {
 		switch dataType := result["type"]; dataType {
 		case "cbg":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			compareResult := outputData(testData["cbg2"])
+			compareResult := dropInternalKeys(testData["cbg2"])
 			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'cbg' result when requesting latest data")
 			}
 			processedResultCount++
 		case "upload":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			compareResult := outputData(testData["upload2"])
+			compareResult := dropInternalKeys(testData["upload2"])
 			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'upload' result when requesting latest data")
 			}
@@ -1185,14 +1185,14 @@ func TestStore_LatestDeviceIdFilter(t *testing.T) {
 		switch dataType := result["type"]; dataType {
 		case "cbg":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			compareResult := outputData(testData["cbg3"])
+			compareResult := dropInternalKeys(testData["cbg3"])
 			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'cbg' result when requesting latest data")
 			}
 			processedResultCount++
 		case "upload":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			compareResult := outputData(testData["upload3"])
+			compareResult := dropInternalKeys(testData["upload3"])
 			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'upload' result when requesting latest data")
 			}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -213,6 +213,16 @@ func testDataForLatestTests() map[string]bson.M {
 	return testData
 }
 
+func outputData(inputData bson.M) bson.M {
+	outputData := bson.M{}
+	for k, v := range inputData {
+		if string(k[0]) != "_" {
+			outputData[k] = v
+		}
+	}
+	return outputData
+}
+
 func storeDataForLatestTests() []interface{} {
 	testData := testDataForLatestTests()
 
@@ -1056,13 +1066,15 @@ func TestStore_LatestNoFilter(t *testing.T) {
 		switch dataType := result["type"]; dataType {
 		case "cbg":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			if !reflect.DeepEqual(result, testData["cbg1"]) {
+			compareResult := outputData(testData["cbg1"])
+			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'cbg' result when requesting latest data")
 			}
 			processedResultCount++
 		case "upload":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			if !reflect.DeepEqual(result, testData["upload1"]) {
+			compareResult := outputData(testData["upload1"])
+			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'upload' result when requesting latest data")
 			}
 			processedResultCount++
@@ -1096,7 +1108,8 @@ func TestStore_LatestTypeFilter(t *testing.T) {
 		switch dataType := result["type"]; dataType {
 		case "cbg":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			if !reflect.DeepEqual(result, testData["cbg1"]) {
+			compareResult := outputData(testData["cbg1"])
+			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'cbg' result when requesting latest data")
 			}
 			processedResultCount++
@@ -1130,13 +1143,15 @@ func TestStore_LatestUploadIdFilter(t *testing.T) {
 		switch dataType := result["type"]; dataType {
 		case "cbg":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			if !reflect.DeepEqual(result, testData["cbg2"]) {
+			compareResult := outputData(testData["cbg2"])
+			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'cbg' result when requesting latest data")
 			}
 			processedResultCount++
 		case "upload":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			if !reflect.DeepEqual(result, testData["upload2"]) {
+			compareResult := outputData(testData["upload2"])
+			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'upload' result when requesting latest data")
 			}
 			processedResultCount++
@@ -1170,13 +1185,15 @@ func TestStore_LatestDeviceIdFilter(t *testing.T) {
 		switch dataType := result["type"]; dataType {
 		case "cbg":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			if !reflect.DeepEqual(result, testData["cbg3"]) {
+			compareResult := outputData(testData["cbg3"])
+			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'cbg' result when requesting latest data")
 			}
 			processedResultCount++
 		case "upload":
 			delete(result, "_id") // _id is assigned by MongoDB. We don't know it up front
-			if !reflect.DeepEqual(result, testData["upload3"]) {
+			compareResult := outputData(testData["upload3"])
+			if !reflect.DeepEqual(result, compareResult) {
 				t.Error("Unexpected 'upload' result when requesting latest data")
 			}
 			processedResultCount++

--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -330,7 +330,7 @@ func main() {
 					}
 					res.Write([]byte("\n"))
 					res.Write(bytes)
-					writeCount += 1
+					writeCount++
 				}
 			}
 		}


### PR DESCRIPTION

Remove the aggregate pipeline, and replace it with multiple Find queries
* Fixes [BACK-1269]

[BACK-1269]: https://tidepool.atlassian.net/browse/BACK-1269