### PR TITLE
Revert "[BACK-1916] Fix formatting of mongo date range queries to use a reliably sortable format"

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -19,9 +19,8 @@ import (
 )
 
 const (
-	dataCollectionName  = "deviceData"
-	dataStoreAPIPrefix  = "api/data/store "
-	RFC3339NanoSortable = "2006-01-02T15:04:05.00000000Z07:00"
+	dataCollectionName = "deviceData"
+	dataStoreAPIPrefix = "api/data/store "
 )
 
 type (
@@ -88,12 +87,7 @@ func cleanDateString(dateString string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	// The Golang implementation of time.RFC3339Nano does not use a fixed number of digits after the
-	// decimal point and therefore is not reliably sortable. And so we use our own custom format for
-	// database range queries that will properly sort any data with time stored as an ISO string.
-	// See https://github.com/golang/go/issues/19635
-	return date.Format(RFC3339NanoSortable), nil
+	return date.Format(time.RFC3339Nano), nil
 }
 
 // GetParams parses a URL to set parameters

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -505,13 +505,8 @@ func TestStore_cleanDateString(t *testing.T) {
 	if dateStr == "" {
 		t.Error("the returned dateStr should not be empty")
 	}
-
-	if dateStr != "2015-10-10T15:00:00.00000000Z" {
-		t.Error("the returned dateStr should be formatted as a sortable RFC3339Nano datetime")
-	}
-
 	if err != nil {
-		t.Error("we should have no error but got ", err.Error())
+		t.Error("we should have no error but go ", err.Error())
 	}
 
 }


### PR DESCRIPTION
Reverts tidepool-org/tide-whisperer#93