### PR TITLE
Replacement of original PR for "Fix formatting of mongo date range queries to use a reliably sortable format" [BACK-1916]

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	dataCollectionName = "deviceData"
-	dataStoreAPIPrefix = "api/data/store "
+	dataCollectionName  = "deviceData"
+	dataStoreAPIPrefix  = "api/data/store "
+	RFC3339NanoSortable = "2006-01-02T15:04:05.00000000Z07:00"
 )
 
 type (
@@ -87,7 +88,12 @@ func cleanDateString(dateString string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return date.Format(time.RFC3339Nano), nil
+
+	// The Golang implementation of time.RFC3339Nano does not use a fixed number of digits after the
+	// decimal point and therefore is not reliably sortable. And so we use our own custom format for
+	// database range queries that will properly sort any data with time stored as an ISO string.
+	// See https://github.com/golang/go/issues/19635
+	return date.Format(RFC3339NanoSortable), nil
 }
 
 // GetParams parses a URL to set parameters

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -505,8 +505,13 @@ func TestStore_cleanDateString(t *testing.T) {
 	if dateStr == "" {
 		t.Error("the returned dateStr should not be empty")
 	}
+
+	if dateStr != "2015-10-10T15:00:00.00000000Z" {
+		t.Error("the returned dateStr should be formatted as a sortable RFC3339Nano datetime")
+	}
+
 	if err != nil {
-		t.Error("we should have no error but go ", err.Error())
+		t.Error("we should have no error but got ", err.Error())
 	}
 
 }


### PR DESCRIPTION
The original PR for [BACK-1916](https://tidepool.atlassian.net/browse/BACK-1916) (tidepool-org/tide-whisperer#93) was accidentally merged (by me) prior to QA completion and then reverted via tidepool-org/tide-whisperer#95

This PR is to replace the original PR and be merged _after_ QA is complete.