### PR TITLE
[BACK-1746] Convert string dates to ISODATE in DB

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -248,7 +248,7 @@ func (c *MongoStoreClient) EnsureIndexes() error {
 		},
 		// END LEGACY INDEXES
 		{
-			Keys: bson.D{{Key: "_userId", Value: 1}, {Key: "deviceModel", Value: 1}},
+			Keys: bson.D{{Key: "_userId", Value: 1}, {Key: "deviceModel", Value: 1}, {Key: "fakefield", Value: 1}},
 			Options: options.Index().
 				SetName("GetLoopableMedtronicDirectUploadIdsAfter_v2_DateTime").
 				SetBackground(true).
@@ -266,7 +266,7 @@ func (c *MongoStoreClient) EnsureIndexes() error {
 				),
 		},
 		{
-			Keys: bson.D{{Key: "_userId", Value: 1}, {Key: "origin.payload.device.manufacturer", Value: 1}},
+			Keys: bson.D{{Key: "_userId", Value: 1}, {Key: "origin.payload.device.manufacturer", Value: 1}, {Key: "fakefield", Value: 1}},
 			Options: options.Index().
 				SetName("HasMedtronicLoopDataAfter_v2_DateTime").
 				SetBackground(true).
@@ -392,7 +392,10 @@ func generateMongoQuery(p *Params) bson.M {
 		}
 
 		if !p.Medtronic && len(p.MedtronicUploadIds) > 0 {
-			medtronicDateTime, _ := time.Parse(medtronicDateFormat, p.MedtronicDate)
+			medtronicDateTime, err := time.Parse(medtronicDateFormat, p.MedtronicDate)
+			if err != nil{
+				medtronicDateTime, _ = time.Parse(time.RFC3339, p.MedtronicDate)
+			}
 			medtronicQuery := []bson.M{
 				{"$or": bson.A{
 					bson.M{"time": bson.M{"$lt": p.MedtronicDate}},
@@ -498,6 +501,9 @@ func (c *MongoStoreClient) HasMedtronicLoopDataAfter(userID string, date string)
 	}
 
 	dateTime, err := time.Parse(medtronicDateFormat, date)
+	if err != nil{
+		dateTime, err = time.Parse(time.RFC3339, date)
+	}
 	if err != nil {
 		return false, errors.New("date is invalid")
 	}
@@ -531,6 +537,9 @@ func (c *MongoStoreClient) GetLoopableMedtronicDirectUploadIdsAfter(userID strin
 	}
 
 	dateTime, err := time.Parse(medtronicDateFormat, date)
+	if err != nil{
+		dateTime, err = time.Parse(time.RFC3339, date)
+	}
 	if err != nil {
 		return nil, errors.New("date is invalid")
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -328,7 +328,7 @@ func TestStore_EnsureIndexes(t *testing.T) {
 					{Key: "$exists", Value: true},
 				}},
 				{Key: "time", Value: bson.D{
-					{Key: "$gte", Value: medtronicIndexDateTime.UnixNano()/1000000},
+					{Key: "$gte", Value: primitive.NewDateTimeFromTime(medtronicIndexDateTime)},
 				}},
 			},
 			Name: "GetLoopableMedtronicDirectUploadIdsAfter_v2_DateTime",
@@ -340,7 +340,7 @@ func TestStore_EnsureIndexes(t *testing.T) {
 				{Key: "_active", Value: true},
 				{Key: "origin.payload.device.manufacturer", Value: "Medtronic"},
 				{Key: "time", Value: bson.D{
-					{Key: "$gte", Value: medtronicIndexDateTime.UnixNano()/1000000},
+					{Key: "$gte", Value: primitive.NewDateTimeFromTime(medtronicIndexDateTime)},
 				}},
 			},
 			Name: "HasMedtronicLoopDataAfter_v2_DateTime",

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -85,11 +85,14 @@ func allParams() *Params {
 	earliestDataTime, _ := time.Parse(time.RFC3339, "2015-10-07T15:00:00Z")
 	latestDataTime, _ := time.Parse(time.RFC3339, "2016-12-13T02:00:00Z")
 
+	dateStart, _ := time.Parse(time.RFC3339, "2015-10-07T15:00:00.000Z")
+	dateEnd, _ := time.Parse(time.RFC3339, "2015-10-11T15:00:00.000Z")
+
 	return &Params{
 		UserID:        "abc123",
 		DeviceID:      "device123",
 		SchemaVersion: &SchemaVersion{Maximum: 2, Minimum: 0},
-		Date:          Date{"2015-10-07T15:00:00.000Z", "2015-10-11T15:00:00.000Z"},
+		Date:          Date{dateStart, dateEnd},
 		Types:         []string{"smbg", "cbg"},
 		SubTypes:      []string{"stuff"},
 		Carelink:      true,
@@ -101,7 +104,7 @@ func allParams() *Params {
 		},
 		Latest:             false,
 		Medtronic:          false,
-		MedtronicDate:      "2017-01-01T00:00:00Z",
+		MedtronicDate:      "2017-01-01",
 		MedtronicUploadIds: []string{"555666777", "888999000"},
 	}
 }
@@ -125,7 +128,7 @@ func typeAndSubtypeQuery() bson.M {
 		SubTypes:           []string{"stuff"},
 		Dexcom:             true,
 		Medtronic:          false,
-		MedtronicDate:      "2017-01-01T00:00:00Z",
+		MedtronicDate:      "2017-01-01",
 		MedtronicUploadIds: []string{"555666777", "888999000"},
 	}
 	return generateMongoQuery(qParams)
@@ -279,11 +282,14 @@ func TestStore_EnsureIndexes(t *testing.T) {
 		return keySlice
 	}
 
+	medtronicIndexDateTime, _ := time.Parse(medtronicDateFormat, medtronicIndexDate)
+
 	expectedIndexes := []mongoIndex{
 		{
 			Key:  makeKeySlice("_id"),
 			Name: "_id_",
 		},
+		// BEGIN legacy indexes
 		{
 			Key:        makeKeySlice("_userId", "deviceModel"),
 			Background: true,
@@ -310,6 +316,34 @@ func TestStore_EnsureIndexes(t *testing.T) {
 				}},
 			},
 			Name: "HasMedtronicLoopDataAfter_v2",
+		},
+		// END legacy indexes
+		{
+			Key: makeKeySlice("_userId", "deviceModel", "fakefield"),
+			Background: true,
+			PartialFilterExpression: bson.D{
+				{Key: "_active", Value: true},
+				{Key: "type", Value: "upload"},
+				{Key: "deviceModel", Value: bson.D{
+					{Key: "$exists", Value: true},
+				}},
+				{Key: "time", Value: bson.D{
+					{Key: "$gte", Value: medtronicIndexDateTime.UnixMilli()},
+				}},
+			},
+			Name: "GetLoopableMedtronicDirectUploadIdsAfter_v2_DateTime",
+		},
+		{
+			Key: makeKeySlice("_userId", "origin.payload.device.manufacturer", "fakefield"),
+			Background: true,
+			PartialFilterExpression: bson.D{
+				{Key: "_active", Value: true},
+				{Key: "origin.payload.device.manufacturer", Value: "Medtronic"},
+				{Key: "time", Value: bson.D{
+					{Key: "$gte", Value: medtronicIndexDateTime.UnixMilli()},
+				}},
+			},
+			Name: "HasMedtronicLoopDataAfter_v2_DateTime",
 		},
 		{
 			Key:        makeKeySlice("_userId", "-time", "type"),
@@ -351,24 +385,44 @@ func TestStore_generateMongoQuery_allParams(t *testing.T) {
 
 	query := allParamsQuery()
 
+	timeStart, _ := time.Parse(time.RFC3339, "2015-10-07T15:00:00.00Z")
+	timeEnd, _ := time.Parse(time.RFC3339, "2015-10-11T15:00:00.00Z")
+
+	dexcomStart, _ := time.Parse(time.RFC3339, "2015-10-07T15:00:00Z")
+	dexcomEnd, _ := time.Parse(time.RFC3339, "2016-12-13T02:00:00Z")
+
+	medtronicEnd, _ := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
+
 	expectedQuery := bson.M{
 		"_userId":  "abc123",
 		"deviceId": "device123",
 		"_active":  true,
 		"type":     bson.M{"$in": strings.Split("smbg,cbg", ",")},
 		"subType":  bson.M{"$in": strings.Split("stuff", ",")},
-		"time": bson.M{
-			"$gte": "2015-10-07T15:00:00.000Z",
-			"$lte": "2015-10-11T15:00:00.000Z"},
+		"$or":      bson.A{
+			bson.M{"time": bson.M{
+				"$gte": "2015-10-07T15:00:00.00000000Z",
+				"$lte": "2015-10-11T15:00:00.00000000Z"}},
+			bson.M{"time": bson.M{"$gte": timeStart, "$lte": timeEnd}},
+		},
 		"$and": []bson.M{
 			{"$or": []bson.M{
 				{"type": bson.M{"$ne": "cbg"}},
 				{"uploadId": bson.M{"$in": []string{"123", "456"}}},
-				{"time": bson.M{"$lt": "2015-10-07T15:00:00Z"}},
-				{"time": bson.M{"$gt": "2016-12-13T02:00:00Z"}},
+				{"$or": bson.A{
+					bson.M{"time": bson.M{"$lt": "2015-10-07T15:00:00Z"}},
+					bson.M{"time": bson.M{"$lt": dexcomStart}},
+				}},
+				{"$or": bson.A{
+					bson.M{"time": bson.M{"$gt": "2016-12-13T02:00:00Z"}},
+					bson.M{"time": bson.M{"$gt": dexcomEnd}},
+				}},
 			}},
 			{"$or": []bson.M{
-				{"time": bson.M{"$lt": "2017-01-01T00:00:00Z"}},
+				{"$or": bson.A{
+					bson.M{"time": bson.M{"$lt": "2017-01-01"}},
+					bson.M{"time": bson.M{"$lt": medtronicEnd}},
+				}},
 				{"type": bson.M{"$nin": []string{"basal", "bolus", "cbg"}}},
 				{"uploadId": bson.M{"$nin": []string{"555666777", "888999000"}}},
 			}},
@@ -385,6 +439,9 @@ func TestStore_generateMongoQuery_allparamsWithUploadId(t *testing.T) {
 
 	query := allParamsIncludingUploadIDQuery()
 
+	timeStart, _ := time.Parse(time.RFC3339, "2015-10-07T15:00:00.00Z")
+	timeEnd, _ := time.Parse(time.RFC3339, "2015-10-11T15:00:00.00Z")
+
 	expectedQuery := bson.M{
 		"_userId":  "abc123",
 		"deviceId": "device123",
@@ -392,9 +449,12 @@ func TestStore_generateMongoQuery_allparamsWithUploadId(t *testing.T) {
 		"type":     bson.M{"$in": strings.Split("smbg,cbg", ",")},
 		"subType":  bson.M{"$in": strings.Split("stuff", ",")},
 		"uploadId": "xyz123",
-		"time": bson.M{
-			"$gte": "2015-10-07T15:00:00.000Z",
-			"$lte": "2015-10-11T15:00:00.000Z"},
+		"$or":      bson.A{
+			bson.M{"time": bson.M{
+				"$gte": "2015-10-07T15:00:00.00000000Z",
+				"$lte": "2015-10-11T15:00:00.00000000Z"}},
+			bson.M{"time": bson.M{"$gte": timeStart, "$lte": timeEnd}},
+		},
 	}
 
 	eq := reflect.DeepEqual(query, expectedQuery)
@@ -426,6 +486,8 @@ func TestStore_generateMongoQuery_noDates(t *testing.T) {
 
 	query := typeAndSubtypeQuery()
 
+	medtronicEnd, _ := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
+
 	expectedQuery := bson.M{
 		"_userId": "abc123",
 		"_active": true,
@@ -436,7 +498,10 @@ func TestStore_generateMongoQuery_noDates(t *testing.T) {
 		},
 		"$and": []bson.M{
 			{"$or": []bson.M{
-				{"time": bson.M{"$lt": "2017-01-01T00:00:00Z"}},
+				{"$or": bson.A{
+					bson.M{"time": bson.M{"$lt": "2017-01-01"}},
+					bson.M{"time": bson.M{"$lt": medtronicEnd}},
+				}},
 				{"type": bson.M{"$nin": []string{"basal", "bolus", "cbg"}}},
 				{"uploadId": bson.M{"$nin": []string{"555666777", "888999000"}}},
 			}},
@@ -461,10 +526,10 @@ func TestStore_Ping(t *testing.T) {
 
 func TestStore_cleanDateString_empty(t *testing.T) {
 
-	dateStr, err := cleanDateString("")
+	date, err := cleanDateString("")
 
-	if dateStr != "" {
-		t.Error("the returned dateStr should have been empty but got ", dateStr)
+	if !date.IsZero() {
+		t.Error("the returned date should have been zero but got ", date)
 	}
 	if err != nil {
 		t.Error("didn't expect an error but got ", err.Error())
@@ -474,10 +539,10 @@ func TestStore_cleanDateString_empty(t *testing.T) {
 
 func TestStore_cleanDateString_nonsensical(t *testing.T) {
 
-	dateStr, err := cleanDateString("blah")
+	date, err := cleanDateString("blah")
 
-	if dateStr != "" {
-		t.Error("the returned dateStr should have been empty but got ", dateStr)
+	if !date.IsZero() {
+		t.Error("the returned date should have been empty zero but got ", date)
 	}
 	if err == nil {
 		t.Error("we should have been given an error")
@@ -487,10 +552,10 @@ func TestStore_cleanDateString_nonsensical(t *testing.T) {
 
 func TestStore_cleanDateString_wrongFormat(t *testing.T) {
 
-	dateStr, err := cleanDateString("2006-20-02T3:04pm")
+	date, err := cleanDateString("2006-20-02T3:04pm")
 
-	if dateStr != "" {
-		t.Error("the returned dateStr should have been empty but got ", dateStr)
+	if !date.IsZero() {
+		t.Error("the returned date should have been empty but got ", date)
 	}
 	if err == nil {
 		t.Error("we should have been given an error")
@@ -500,14 +565,15 @@ func TestStore_cleanDateString_wrongFormat(t *testing.T) {
 
 func TestStore_cleanDateString(t *testing.T) {
 
-	dateStr, err := cleanDateString("2015-10-10T15:00:00.000Z")
+	date, err := cleanDateString("2015-10-10T15:00:00.000Z")
+	targetDate, _ := time.Parse(RFC3339NanoSortable, "2015-10-10T15:00:00.00000000Z")
 
-	if dateStr == "" {
-		t.Error("the returned dateStr should not be empty")
+	if date.IsZero() {
+		t.Error("the returned date should not be empty")
 	}
 
-	if dateStr != "2015-10-10T15:00:00.00000000Z" {
-		t.Error("the returned dateStr should be formatted as a sortable RFC3339Nano datetime")
+	if date != targetDate {
+		t.Error("the returned date should equal 2015-10-10T15:00:00.00000000Z")
 	}
 
 	if err != nil {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -328,7 +328,7 @@ func TestStore_EnsureIndexes(t *testing.T) {
 					{Key: "$exists", Value: true},
 				}},
 				{Key: "time", Value: bson.D{
-					{Key: "$gte", Value: medtronicIndexDateTime.UnixMilli()},
+					{Key: "$gte", Value: medtronicIndexDateTime.UnixNano()/1000000},
 				}},
 			},
 			Name: "GetLoopableMedtronicDirectUploadIdsAfter_v2_DateTime",
@@ -340,7 +340,7 @@ func TestStore_EnsureIndexes(t *testing.T) {
 				{Key: "_active", Value: true},
 				{Key: "origin.payload.device.manufacturer", Value: "Medtronic"},
 				{Key: "time", Value: bson.D{
-					{Key: "$gte", Value: medtronicIndexDateTime.UnixMilli()},
+					{Key: "$gte", Value: medtronicIndexDateTime.UnixNano()/1000000},
 				}},
 			},
 			Name: "HasMedtronicLoopDataAfter_v2_DateTime",

--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -333,11 +333,6 @@ func main() {
 			}
 
 			if len(results) > 0 {
-				// HACK convert deviceTime to string before marshal, to avoid modifying the results map above
-				if deviceTime, ok := results["deviceTime"].(primitive.DateTime); ok {
-					results["deviceTime"] = deviceTime.Time().Format(DeviceTimeFormat)
-				}
-
 				if bytes, err := json.Marshal(results); err != nil {
 					mongoErrorCount.WithLabelValues("marshal").Inc()
 					log.Printf("%s request %s user %s Marshal returned error: %s", dataAPIPrefix, requestID, userID, err)

--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -80,7 +80,6 @@ const (
 	dataAPIPrefix             = "api/data "
 	medtronicLoopBoundaryDate = "2017-09-01"
 	slowQueryDuration         = 0.1 // seconds
-	DeviceTimeFormat          = "2006-01-02T15:04:05"
 )
 
 //set the intenal message that we will use for logging

--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -80,7 +80,7 @@ var (
 
 const (
 	dataAPIPrefix             = "api/data "
-	medtronicLoopBoundaryDateUnix = 1504238400
+	medtronicLoopBoundaryDate = "2017-09-01"
 	slowQueryDuration         = 0.1 // seconds
 	DeviceTimeFormat          = "2006-01-02T15:04:05"
 )
@@ -93,8 +93,6 @@ func (d detailedError) setInternalMessage(internal error) detailedError {
 
 func main() {
 	var config Config
-
-	medtronicLoopBoundaryDate := time.Unix(medtronicLoopBoundaryDateUnix, 0).UTC()
 
 	log.SetPrefix(dataAPIPrefix)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -336,11 +334,8 @@ func main() {
 
 			if len(results) > 0 {
 				// HACK convert deviceTime to string before marshal, to avoid modifying the results map above
-				switch v := results["deviceTime"].(type) {
-					case primitive.DateTime:
-						results["deviceTime"] = v.Time().Format(DeviceTimeFormat)
-					case string:
-						// do nothing
+				if deviceTime, ok := results["deviceTime"].(primitive.DateTime); ok {
+					results["deviceTime"] = deviceTime.Time().Format(DeviceTimeFormat)
 				}
 
 				if bytes, err := json.Marshal(results); err != nil {

--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -13,8 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson/primitive"
-
 	httpgzip "github.com/daaku/go.httpgzip"
 	"github.com/google/uuid"
 	"github.com/gorilla/pat"


### PR DESCRIPTION
This has been tested using uploader and postman APITests along with manual testing, and covers all found cases using string dates.
Unit tests will most likely fail for now, as they manually specify date strings, and I believe it will be best to gather feedback on the approach, and discuss unit testing strategies before adjusting them.