### PR TITLE
[BACK-1758] Single read and write from appropriate collection for datum and uploads.

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -651,7 +651,8 @@ func (c *MongoStoreClient) GetDeviceData(p *Params) (StorageIterator, error) {
 	switch {
 	case len(p.Types) == 1 && p.Types[0] == "upload":
 		return dataSetsCollection(c).Find(c.context, generateMongoQuery(p), opts)
-	case len(p.Types) > 0 && !contains("upload", p.Types):
+	// Have to check for empty string as sometimes that is the type sent.
+	case len(p.Types) > 0 && !contains("upload", p.Types) && p.Types[0] != "":
 		return dataCollection(c).Find(c.context, generateMongoQuery(p), opts)
 	}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -106,15 +106,6 @@ func getCursors(exPlans interface{}) []string {
 	return cursors
 }
 
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if strings.Contains(a, e) {
-			return true
-		}
-	}
-	return false
-}
-
 func basicQuery() bson.M {
 	qParams := &Params{
 		UserID:        "abc123",

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -50,18 +50,28 @@ func before(t *testing.T, docs ...interface{}) *MongoStoreClient {
 	dataSetsCollection(store).Drop(context.TODO())
 
 	if len(docs) > 0 {
-		if _, err := dataCollection(store).InsertMany(store.context, docs); err != nil {
-			t.Error("Unable to insert documents", err)
-		}
-		// Insert into dataSetsCollection as well if type == "upload" Note
-		// still inserting into dataCollection to mimick data type upload
-		// being in both collections as migration happens.
+		// Once uploads are migrated, we have to mimic the behaviour of the
+		// production services where they write uploads to the deviceDataSets
+		// collection and data to the deviceData collection
 		for _, docRaw := range docs {
-			doc, ok := docRaw.(bson.M)
-			if !ok || doc["type"] != "upload" {
-				continue
+			var datumType string
+			switch typedDoc := docRaw.(type) {
+			case TestDataSchema:
+				if typedDoc.Type != nil {
+					datumType = *typedDoc.Type
+				}
+			case bson.M:
+				if typ, ok := typedDoc["type"].(string); ok {
+					datumType = typ
+				}
+			default:
+				t.Errorf("Could not insert unhandled type %T into appropriate collection", docRaw)
 			}
-			if _, err := dataSetsCollection(store).InsertOne(store.context, doc); err != nil {
+			collection := dataCollection(store)
+			if datumType == "upload" {
+				collection = dataSetsCollection(store)
+			}
+			if _, err := collection.InsertOne(store.context, docRaw); err != nil {
 				t.Error("Unable to insert document", err)
 			}
 		}

--- a/tide-whisperer.go
+++ b/tide-whisperer.go
@@ -187,7 +187,11 @@ func main() {
 
 	storage := store.NewMongoStoreClient(&config.Mongo)
 	defer storage.Disconnect()
-	storage.EnsureIndexes()
+
+	disableIndexCreation, found := os.LookupEnv("TIDEPOOL_DISABLE_INDEX_CREATION")
+	if !found || disableIndexCreation != "true" {
+		storage.EnsureIndexes()
+	}
 
 	router := pat.New()
 


### PR DESCRIPTION
This is meant to be merged **AFTER** dual read/writes for tide-whisperer, platform-data and jellyfish have been deployed and then the migrator of uploads to the `deviceDataSets` collection is ran to completion.

This removes the dual read/write of data and does a single read and write from the appropriate data collection.
Reads and writes to `deviceData` collection for a datum and `deviceDataSets` for a dataSet/upload.

