### PR TITLE
[BACK-3493] Add sample interval filter

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -392,7 +392,7 @@ func generateMongoQuery(p *Params) bson.M {
 	if p.SampleIntervalMinimum > 0 {
 		groupDataQuery["$or"] = []bson.M{
 			{"type": bson.M{"$ne": "cbg"}},
-			{"sampleInterval": bson.M{"$exist": false}},
+			{"sampleInterval": bson.M{"$exists": false}},
 			{"sampleInterval": bson.M{"$gte": p.SampleIntervalMinimum}},
 		}
 	}


### PR DESCRIPTION
- Add sample interval filter
- https://tidepool.atlassian.net/browse/BACK-3493

@jh-bate Not tested, but I believe this is correct. When the `sampleFilterMinimum` query parameter is specified and greater than 0, then will only return `cbg` data that is greater than or equal to `sampleFilterMinimum`. 